### PR TITLE
Fix watchOS simulator target for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,6 @@ jobs:
 
       - name: Run tests (watchOS)
         run: |
-            xcodebuild test -scheme "BatteryTracker Watch App" -destination 'platform=watchOS Simulator,name=Any watchOS Simulator Device' | xcpretty
+            xcodebuild test \
+              -scheme "BatteryTracker Watch App" \
+              -destination 'generic/platform=watchOS' | xcpretty


### PR DESCRIPTION
## Summary
- update CI workflow to use a valid watchOS simulator destination

## Testing
- `git commit`

------
https://chatgpt.com/codex/tasks/task_e_687d0771bde08323a6e412d46c692a47