### PR TITLE
Fix ContentView to use environment object

### DIFF
--- a/BatteryTracker Watch App/ContentView.swift
+++ b/BatteryTracker Watch App/ContentView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct ContentView: View {
-    @StateObject var viewModel = BatteryViewModel()
+    @EnvironmentObject var viewModel: BatteryViewModel
 
     var body: some View {
         let now = Date()


### PR DESCRIPTION
## Summary
- use the `BatteryViewModel` injected by `BatteryTrackerApp` instead of creating a new instance in `ContentView`

## Testing
- `xcodebuild test -scheme "BatteryTracker Watch App" -destination 'platform=watchOS Simulator,name=Apple Watch Series 9 (45mm)'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d0d6af1ec8323889756027b61699a