### PR TITLE
Limit saved battery entries to 24 hours

### DIFF
--- a/BatteryTracker Watch App/BatteryViewModel.swift
+++ b/BatteryTracker Watch App/BatteryViewModel.swift
@@ -18,6 +18,8 @@ class BatteryViewModel: ObservableObject {
         }
     }
 
+    private let maxHistoryDuration: TimeInterval = 24 * 60 * 60 // 24 hours
+
     private var timer: Timer?
     private let historyKey = "batteryHistory"
 
@@ -52,7 +54,8 @@ class BatteryViewModel: ObservableObject {
             level: WKInterfaceDevice.current().batteryLevel,
             state: WKInterfaceDevice.current().batteryState
         )
-        history.append(entry)
+        let cutoff = Date().addingTimeInterval(-maxHistoryDuration)
+        history = (history + [entry]).filter { $0.timestamp >= cutoff }
     }
 
     // MARK: - Persistence
@@ -66,7 +69,8 @@ class BatteryViewModel: ObservableObject {
     private func loadHistory() {
         if let data = UserDefaults.standard.data(forKey: historyKey),
            let decoded = try? JSONDecoder().decode([BatteryEntry].self, from: data) {
-            history = decoded
+            let cutoff = Date().addingTimeInterval(-maxHistoryDuration)
+            history = decoded.filter { $0.timestamp >= cutoff }
         }
     }
 }


### PR DESCRIPTION
## Summary
- keep only the last 24h of logged battery entries

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687d0fee0fec8323afa9c051d1005141