### PR TITLE
Add log interval setting and widget complication

### DIFF
--- a/BatteryTracker Watch App/ContentView.swift
+++ b/BatteryTracker Watch App/ContentView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct ContentView: View {
-    @StateObject var viewModel = BatteryViewModel()
+    @EnvironmentObject var viewModel: BatteryViewModel
 
     var body: some View {
         let now = Date()
@@ -14,6 +14,12 @@ struct ContentView: View {
 
                 Text("Current Level: \(Int(viewModel.batteryLevel * 100))%")
                 Text("Current State: \(stateDescription(viewModel.batteryState))")
+                Picker("Interval", selection: $viewModel.logInterval) {
+                    ForEach([5,10,15,20,30,60], id: \.self) { minutes in
+                        Text("\(minutes) min").tag(TimeInterval(minutes * 60))
+                    }
+                }
+                .pickerStyle(.navigationLink)
 
                 Divider()
 

--- a/BatteryTracker Watch AppTests/BatteryViewModelTests.swift
+++ b/BatteryTracker Watch AppTests/BatteryViewModelTests.swift
@@ -29,4 +29,12 @@ class BatteryViewModelTests: XCTestCase {
         XCTAssertEqual(filtered.count, 1)
         XCTAssertEqual(filtered.first?.level, 0.8)
     }
+
+    func testLogIntervalPersistence() {
+        UserDefaults.standard.removeObject(forKey: "logInterval")
+        let viewModel = BatteryViewModel(skipInitialLog: true)
+        viewModel.logInterval = 300
+        let newVM = BatteryViewModel(skipInitialLog: true)
+        XCTAssertEqual(newVM.logInterval, 300)
+    }
 }

--- a/BatteryWidget/BatteryWidget.swift
+++ b/BatteryWidget/BatteryWidget.swift
@@ -1,0 +1,54 @@
+import WidgetKit
+import SwiftUI
+import WatchKit
+
+struct BatteryWidgetEntry: TimelineEntry {
+    let date: Date
+    let level: Float
+}
+
+struct BatteryProvider: TimelineProvider {
+    func placeholder(in context: Context) -> BatteryWidgetEntry {
+        BatteryWidgetEntry(date: Date(), level: WKInterfaceDevice.current().batteryLevel)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (BatteryWidgetEntry) -> ()) {
+        let entry = BatteryWidgetEntry(date: Date(), level: WKInterfaceDevice.current().batteryLevel)
+        completion(entry)
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<BatteryWidgetEntry>) -> ()) {
+        let level = WKInterfaceDevice.current().batteryLevel
+        let entry = BatteryWidgetEntry(date: Date(), level: level)
+        let refresh = Calendar.current.date(byAdding: .minute, value: 10, to: Date()) ?? Date().addingTimeInterval(600)
+        completion(Timeline(entries: [entry], policy: .after(refresh)))
+    }
+}
+
+struct BatteryWidgetView : View {
+    var entry: BatteryProvider.Entry
+
+    var body: some View {
+        Gauge(value: Double(entry.level), in: 0...1) {
+            Text("Battery")
+        } currentValueLabel: {
+            Text("\(Int(entry.level * 100))%")
+        }
+        .gaugeStyle(.accessoryCircular)
+        .tint(entry.level < 0.2 ? .red : .green)
+    }
+}
+
+@main
+struct BatteryWidget: Widget {
+    let kind: String = "BatteryWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: BatteryProvider()) { entry in
+            BatteryWidgetView(entry: entry)
+        }
+        .supportedFamilies([.accessoryCircular, .accessoryCorner, .accessoryInline])
+        .configurationDisplayName("Battery Level")
+        .description("Shows current battery level and turns red when low.")
+    }
+}


### PR DESCRIPTION
## Summary
- allow the logging interval to be changed at runtime
- persist the selected logging interval to `UserDefaults`
- show a picker in `ContentView` for changing the interval
- add a simple WidgetKit complication that displays the battery level
- test persistence of the logging interval

## Testing
- `xcodebuild test -scheme "BatteryTracker Watch App" -destination 'platform=watchOS Simulator,name=Apple Watch Series 9 (45mm)'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d0d6af1ec8323889756027b61699a