### PR TITLE
Ensure watch battery timer starts immediately

### DIFF
--- a/BatteryTracker Watch App/BatteryViewModel.swift
+++ b/BatteryTracker Watch App/BatteryViewModel.swift
@@ -26,7 +26,7 @@ class BatteryViewModel: ObservableObject {
 
     private let maxHistoryDuration: TimeInterval = 24 * 60 * 60 // 24 hours
 
-    private var timer: Timer?
+    private(set) var timer: Timer?
     private let historyKey = "batteryHistory"
     private let intervalKey = "logInterval"
 
@@ -40,6 +40,7 @@ class BatteryViewModel: ObservableObject {
         if !skipInitialLog {
             logBatteryEntry()
         }
+        startTimer()
     }
 
     deinit {

--- a/BatteryTracker Watch AppTests/BatteryViewModelTests.swift
+++ b/BatteryTracker Watch AppTests/BatteryViewModelTests.swift
@@ -37,4 +37,10 @@ class BatteryViewModelTests: XCTestCase {
         let newVM = BatteryViewModel(skipInitialLog: true)
         XCTAssertEqual(newVM.logInterval, 300)
     }
+
+    func testTimerStartsOnInit() {
+        let viewModel = BatteryViewModel(skipInitialLog: true)
+        XCTAssertNotNil(viewModel.timer)
+        XCTAssertTrue(viewModel.timer?.isValid ?? false)
+    }
 }


### PR DESCRIPTION
## Summary
- expose timer to tests
- start battery logging timer inside `BatteryViewModel` init
- verify timer is initialized in unit tests

## Testing
- `xcodebuild -list` *(fails: command not found)*
- `swift test` *(fails: manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d154ec7708323a2b984d4322282fc