### PR TITLE
Add Info.plist for BatteryWidget

### DIFF
--- a/BatteryTracker.xcodeproj/project.pbxproj
+++ b/BatteryTracker.xcodeproj/project.pbxproj
@@ -736,12 +736,11 @@
                                 CODE_SIGN_STYLE = Automatic;
                                 CURRENT_PROJECT_VERSION = 1;
                                 DEVELOPMENT_TEAM = Y9DM8L58T3;
-                                GENERATE_INFOPLIST_FILE = YES;
-                                INFOPLIST_KEY_CFBundleDisplayName = BatteryWidget;
-                                LD_RUNPATH_SEARCH_PATHS = (
-                                        "$(inherited)",
-                                        "@executable_path/Frameworks",
-                                );
+                               INFOPLIST_FILE = BatteryWidget/Info.plist;
+                               LD_RUNPATH_SEARCH_PATHS = (
+                                       "$(inherited)",
+                                       "@executable_path/Frameworks",
+                               );
                                 MARKETING_VERSION = 1.0;
                                 PRODUCT_BUNDLE_IDENTIFIER = com.scrumcenter.BatteryWidget;
                                 PRODUCT_NAME = "$(TARGET_NAME)";
@@ -759,12 +758,11 @@
                                 CODE_SIGN_STYLE = Automatic;
                                 CURRENT_PROJECT_VERSION = 1;
                                 DEVELOPMENT_TEAM = Y9DM8L58T3;
-                                GENERATE_INFOPLIST_FILE = YES;
-                                INFOPLIST_KEY_CFBundleDisplayName = BatteryWidget;
-                                LD_RUNPATH_SEARCH_PATHS = (
-                                        "$(inherited)",
-                                        "@executable_path/Frameworks",
-                                );
+                               INFOPLIST_FILE = BatteryWidget/Info.plist;
+                               LD_RUNPATH_SEARCH_PATHS = (
+                                       "$(inherited)",
+                                       "@executable_path/Frameworks",
+                               );
                                 MARKETING_VERSION = 1.0;
                                 PRODUCT_BUNDLE_IDENTIFIER = com.scrumcenter.BatteryWidget;
                                 PRODUCT_NAME = "$(TARGET_NAME)";

--- a/BatteryWidget/Info.plist
+++ b/BatteryWidget/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>BatteryWidget</string>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.widgetkit-extension</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add a minimal `BatteryWidget/Info.plist`
- configure the BatteryWidget target to use the new plist

## Testing
- `xcodebuild` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d28f003388323af438f63789f87d9